### PR TITLE
fix(registry): name components from the segment after the ui alias

### DIFF
--- a/docs/scripts/build-registry.ts
+++ b/docs/scripts/build-registry.ts
@@ -34,6 +34,21 @@ function validateRegistry(registry: Registry['items']) {
 	if (selfReferenceError) {
 		throw new Error(selfReferenceError);
 	}
+
+	const names = new Set(registry.map((item) => item.name));
+	const unresolvedError = registry
+		.flatMap((item) =>
+			(item.registryDependencies ?? [])
+				.filter((dep) => !dep.startsWith('http') && !names.has(dep))
+				.map(
+					(dep) =>
+						`Registry item '${item.name}' depends on '${dep}', which is not in the registry`
+				)
+		)
+		.join('\n');
+	if (unresolvedError) {
+		throw new Error(unresolvedError);
+	}
 }
 
 export async function build(): Promise<void> {

--- a/docs/scripts/registry.ts
+++ b/docs/scripts/registry.ts
@@ -248,12 +248,16 @@ async function getFileDependencies(
 		}
 
 		if (source.startsWith(REGISTRY_DEPENDENCY) && source !== UTILS_PATH) {
-			if (source.includes('ui')) {
-				const component = source.split('/').at(-2)!;
-				registryDependencies.add(component);
-			} else if (source.includes('hook')) {
-				const hook = source.split('/').at(-1)!.split('.')[0]!;
-				registryDependencies.add(hook);
+			// Match on path SEGMENTS, and name the component from the segment AFTER the
+			// alias: an import may point at a file ('ui/input/index.js') or at the
+			// directory alone ('ui/input'), so the last-but-one segment is not the name.
+			const segments = source.split('/');
+			const uiIndex = segments.indexOf('ui');
+
+			if (uiIndex !== -1 && segments[uiIndex + 1]) {
+				registryDependencies.add(segments[uiIndex + 1]!);
+			} else if (segments.includes('hooks') || segments.includes('hook')) {
+				registryDependencies.add(segments.at(-1)!.split('.')[0]!);
 			}
 		}
 	};

--- a/docs/src/lib/registry/ui/password/password.svelte
+++ b/docs/src/lib/registry/ui/password/password.svelte
@@ -25,7 +25,7 @@
 <script lang="ts">
 	import Icon from '@iconify/svelte';
 	import { cn, type WithElementRef } from '$lib/utils.js';
-	import { Input } from '$lib/registry/ui/input';
+	import { Input } from '$lib/registry/ui/input/index.js';
 	import type { HTMLInputAttributes } from 'svelte/elements';
 
 	let {


### PR DESCRIPTION
The dependency extractor read `source.split('/').at(-2)`, which assumes every registry import ends in a filename. A directory-form import — `$lib/registry/ui/input`, used only by password.svelte — resolved to `ui` instead of `input`, so the published registry declared a dependency on a registry item that does not exist and `lily-svelte add --all` aborted for all 62 components.

- match `ui` / `hooks` as path segments rather than substrings, and take the component name from the segment after the alias, so both the file form and the directory form resolve correctly
- normalise password.svelte to the file form the other 12 cross-component imports use
- fail the registry build when a registryDependencies entry does not resolve to a real item, so this cannot ship again